### PR TITLE
Remove spurious ";;" in package description line

### DIFF
--- a/el-pocket.el
+++ b/el-pocket.el
@@ -1,4 +1,4 @@
-;;; el-pocket.el --- Read and write to Pocket (getpocket.com) ;; -*- lexical-binding: t -*-
+;;; el-pocket.el --- Read and write to Pocket (getpocket.com) -*- lexical-binding: t -*-
 ;; Author: Tod Davies <davies.t.o@gmail.com>
 ;; Created: 4 Aug 2014
 ;; Last Updated: 28 Jan 2015


### PR DESCRIPTION
This secondary comment marker is unnecessary, and is assumed by
package.el to be part of the package description text.
