### PR TITLE
Add el-pocket-add-url.

### DIFF
--- a/el-pocket.el
+++ b/el-pocket.el
@@ -205,6 +205,11 @@
          :extra-headers extra-headers))
     (el-pocket-access-not-granted)))
 
+(defun el-pocket-add-url (url &optional ignore)
+  "Add URL to pocket."
+  (interactive (browse-url-interactive-arg "URL: "))
+  (el-pocket-add url))
+
 (provide 'el-pocket)
 
 ;;; el-pocket.el ends here


### PR DESCRIPTION
The function el-pocket-add-url sets by default the url your cursor is over when
you want to add an url to pocket.
